### PR TITLE
update shop sample to new send/recv API

### DIFF
--- a/shop/backend-operon/src/api.ts
+++ b/shop/backend-operon/src/api.ts
@@ -63,7 +63,7 @@ async function startServer(port: number) {
 
     app.post('/api/add_to_cart', asyncHandler(async (req: Request, res: Response) => {
         const { username, product_id } = req.body;
-        await operon.addToCart(username, product_id);
+        await operon.addToCart(username, product_id.toString());
         res.status(200).send('Success');
     }));
 


### PR DESCRIPTION
https://github.com/dbos-inc/operon/pull/50 changed the API for send and recv. This PR updates the shop sample for the new API.

Note, `operon.recv` was removed by that PR. The shop sample used this API to receive the Stripe checkout URL from `paymentWorkflow`. In the absence of a general purpose mechanism for a workflow to communicate to the host enviroment to signal for user input, this PR adds a new `checkoutUrlWorkflow` that simply await listening for a `checkout_url_topic` signal from `paymentWorkflow`. The `runPaymentWorkflow` starts both workflows, awaiting on the completion of `checkoutUrlWorkflow`