### PR TITLE
Add test in bank CI

### DIFF
--- a/.github/workflows/bank.yml
+++ b/.github/workflows/bank.yml
@@ -69,9 +69,6 @@ jobs:
           POSTGRES_PORT: 5432
           POSTGRES_PASSWORD: dbos
           BANK_PORT: 8081
-      - name: Start Keycloak
-        working-directory: bank/
-        run: scripts/start_keycloak_docker.sh
       - name: Compile Bank Server
         working-directory: bank/bank-backend/
         run: |
@@ -81,10 +78,10 @@ jobs:
           npm run build
           npm test
         env:
+          PGPASSWORD: bank
           # The hostname used to communicate with the PostgreSQL service container
           POSTGRES_HOST: localhost
           # The default PostgreSQL port
           POSTGRES_PORT: 5432
-          POSTGRES_PASSWORD: dbos
           BANK_PORT: 8081
           NPM_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/bank/bank-backend/src/runtime.test.ts
+++ b/bank/bank-backend/src/runtime.test.ts
@@ -20,6 +20,7 @@ async function waitForMessageTest(command: ChildProcess, port: string) {
     };
 
     stdout.on("data", onData);
+    stderr.on("data", onData);
 
     command.on("error", (error) => {
       reject(error); // Reject promise on command error


### PR DESCRIPTION
This PR adds the `npm test` command to bank.yaml so we can actually test the server on Github CI.