### PR TITLE
Aligning the e-commerce README.md with npm script names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# VSCode settings
+.vscode/settings.json
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged

--- a/e-commerce/README.md
+++ b/e-commerce/README.md
@@ -43,16 +43,15 @@ Once the `dbos-config.yaml` files have been updated, you also need to create the
 The `start_postgres_docker.sh` script does this by calling `CREATE DATABASE shop;` and `CREATE DATABASE payment;` 
 via [psql](https://www.postgresql.org/docs/current/app-psql.html) in the docker container.
 
-Additionally, you need to configure the schemas for those databases via the `npm run setup` command in each of the backend package folders.
-Both shop and payment use [knex.js](https://knexjs.org/) as a database access library.
-The npm setup command simply runs `knex migration` and `knex seed` to configure each database appropriately.
+Additionally, you need to configure the schemas for those databases via the `npm run db:setup` command in each of the backend package folders.
+Both shop and payment use [knex.js](https://knexjs.org/) as a database access library to manage migrations and seed data.
 
 ### Run the Demo
 
-Each of the four parts of the demo must run in its own terminal window. 
+Each of the four parts of the demo must run in its own terminal window.
 For each setup, each package has a single npm command that is used to build and launch the package
 
-* For payment-backend and shop-backend, run `npm run start` to build and launch the app
+* For payment-backend and shop-backend, run `npx dbos-sdk start` to build and launch the app
 
 * For shop-frontend, run `npm run dev` to launch the app
 * To run with a backend in the cloud, export NEXT_PUBLIC_SHOP_BACKEND=<url to shop backend>

--- a/e-commerce/payment-backend/package.json
+++ b/e-commerce/payment-backend/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "build": "tsc",
+    "db:setup": "npx knex migrate:up",
     "test": "npx knex migrate:rollback && npx knex migrate:up && jest"
   },
   "devDependencies": {

--- a/e-commerce/shop-backend/package.json
+++ b/e-commerce/shop-backend/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "tsc",
     "test": "npx knex migrate:rollback && npx knex migrate:up && jest",
+    "db:setup": "npx knex migrate:up && npx knex seed:run",
     "lint": "eslint src",
     "lint-fix": "eslint --fix src"
   },

--- a/e-commerce/start_postgres_docker.sh
+++ b/e-commerce/start_postgres_docker.sh
@@ -24,8 +24,5 @@ docker exec dbos-ecommerce psql -U postgres -c "CREATE DATABASE shop;"
 docker exec dbos-ecommerce psql -U postgres -c "CREATE DATABASE payment;"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-npm run --prefix $SCRIPT_DIR/shop-backend migrate
-npm run --prefix $SCRIPT_DIR/payment-backend migrate
-
-# Add Seed Data
-npm run --prefix $SCRIPT_DIR/shop-backend seed
+npm run --prefix $SCRIPT_DIR/shop-backend db:setup
+npm run --prefix $SCRIPT_DIR/payment-backend db:setup


### PR DESCRIPTION
Hello DBOS team 👋 

Great to chat earlier! As mentioned, here are some minor fixes to the documentation around the e-commerce app's setup scripts.  Definitely looks like there has been some churn in what the npm scripts are named and how they are organized, so I went with prefixing a new command named `db:setup` so it's clearly DB related.  Happy to discuss if there are other preferences (or feel free to use this PR as a starting point).