### PR TITLE
TPC-C Default Timestamp

### DIFF
--- a/tpcc/README.md
+++ b/tpcc/README.md
@@ -62,5 +62,10 @@ curl http://localhost:3000/neworder/1
 > [!NOTE]
 > We deliberately make 1% of the NewOrder transaction fails, so it's normal to see `Error new order: I_ID=-12345 not found!` occasionally.
 
+You can also run unit tests:
+```bash
+npm test
+```
+
 ## Deploying to DBOS Cloud
 Coming soon...

--- a/tpcc/migrations/20240212161006_create_tpcc_tables.js
+++ b/tpcc/migrations/20240212161006_create_tpcc_tables.js
@@ -39,7 +39,7 @@ exports.up = async function(knex) {
     table.specificType('c_state', 'char(2)');
     table.specificType('c_zip', 'char(9)');
     table.specificType('c_phone', 'char(16)');
-    table.timestamp('c_since');
+    table.timestamp('c_since').defaultTo(knex.fn.now());
     table.specificType('c_credit', 'char(2)');
     table.decimal('c_credit_lim', 12, 2);
     table.decimal('c_discount', 4, 4);
@@ -57,7 +57,7 @@ exports.up = async function(knex) {
     table.integer('h_c_w_id').notNullable();
     table.integer('h_d_id').notNullable();
     table.integer('h_w_id').notNullable();
-    table.timestamp('h_date');
+    table.timestamp('h_date').defaultTo(knex.fn.now());
     table.decimal('h_amount', 6, 2);
     table.string('h_data', 24);
   });
@@ -74,7 +74,7 @@ exports.up = async function(knex) {
     table.integer('o_d_id').notNullable();
     table.integer('o_w_id').notNullable();
     table.integer('o_c_id');
-    table.timestamp('o_entry_d');
+    table.timestamp('o_entry_d').defaultTo(knex.fn.now());
     table.integer('o_carrier_id');
     table.integer('o_ol_cnt');
     table.integer('o_all_local');


### PR DESCRIPTION
This PR fixes an issue where the timestamp was NULL in history and orders tables. Now set default values to timestmaps.