### PR TITLE
Add 'dev' script to package.json

### DIFF
--- a/e-commerce/payment-frontend/package.json
+++ b/e-commerce/payment-frontend/package.json
@@ -4,7 +4,8 @@
   "main": "dist/app.js",
   "scripts": {
     "build": "tsc",
-    "start": "npm run build && node dist/app.js"
+    "start": "npm run build && node dist/app.js",
+    "dev": "npm run build && node dist/app.js"
   },
   "dependencies": {
     "@dbos-inc/dbos-sdk": "^0.8.62",


### PR DESCRIPTION
The payment-frontend package is missing a 'dev' script in the package.json and throwing an error on build and execute. I added the following dev script to the package.json in the e-commerce demo app: , "dev": "npm run build && node dist/app.js"