### PR TITLE
Call a communicator to get the curr time, instead of Date.now

### DIFF
--- a/yky-social/src/YKYOperations.ts
+++ b/yky-social/src/YKYOperations.ts
@@ -470,7 +470,7 @@ static async mediaUpload(ctx: WorkflowContext, mtype: string, mediaId: string, m
         // It might be a good idea to clobber the s3 key in case it arrived but we weren't told.
         //   (The access key duration is less than the time we wait, so it can't be started.)
         // TODO: perhaps put this operation in a communicator later.
-        await this.ensureS3FileDropped(ctx, mediaFile, bucket);
+        await Operations.ensureS3FileDropped(ctx, mediaFile, bucket);
     }
     return {};
 }

--- a/yky-social/src/YKYOperations.ts
+++ b/yky-social/src/YKYOperations.ts
@@ -144,7 +144,7 @@ static async getPost(ctx: ORMTC, _curUid: string, post:string) :
 // Returns other user's login, profile (if requested), our listing for his status, and his for us
 @Transaction({readOnly: true})
 static async findUser(ctx: ORMTC, curUid:string, uname:string, getProfile:boolean, getStatus: boolean) :
-   Promise<[UserLogin?, UserProfile?, GraphType?, GraphType?]> 
+   Promise<[UserLogin?, UserProfile?, GraphType?, GraphType?]>
 {
     const manager = ctx.client;
     const userRep = manager.getRepository(UserLogin);
@@ -184,7 +184,7 @@ static async findUser(ctx: ORMTC, curUid:string, uname:string, getProfile:boolea
     if (getProfile) {
         const upRep = manager.getRepository(UserProfile);
         const up = await upRep.findOneBy({id: otherUser.id});
-        
+
         // Future: If we're not friends, we could strip part of this out based on public/private preferences
         if (up) {
             profile = up;
@@ -469,6 +469,7 @@ static async mediaUpload(ctx: WorkflowContext, mtype: string, mediaId: string, m
         // No need to make a database record, or, at this point, roll anything back.
         // It might be a good idea to clobber the s3 key in case it arrived but we weren't told.
         //   (The access key duration is less than the time we wait, so it can't be started.)
+        // TODO: perhaps put this operation in a communicator later.
         await this.ensureS3FileDropped(ctx, mediaFile, bucket);
     }
     return {};


### PR DESCRIPTION
Also used the same communicator in a non-workflow function, just for the sake of uniformity