### PR TITLE
Add the crash button and instructions for a demo. 

### DIFF
--- a/bank/bank-backend/package-lock.json
+++ b/bank/bank-backend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
-        "@dbos-inc/dbos-sdk": "^1.15.9",
+        "@dbos-inc/dbos-sdk": "^1.16.12",
         "@koa/bodyparser": "^5.0.0",
         "@koa/cors": "^5.0.0",
         "@koa/router": "^12.0.0",
@@ -771,12 +771,9 @@
       }
     },
     "node_modules/@dbos-inc/dbos-sdk": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/@dbos-inc/dbos-sdk/-/dbos-sdk-1.15.9.tgz",
-      "integrity": "sha512-2omgN7TVdUpq6zFHQfbxMUvlCyi02aNNKa//4iTWCzQE9VychF9qgwpORjRh6WqiWVE0D41QewriVGFKURY1HA==",
-      "workspaces": [
-        "packages/*"
-      ],
+      "version": "1.16.12",
+      "resolved": "https://registry.npmjs.org/@dbos-inc/dbos-sdk/-/dbos-sdk-1.16.12.tgz",
+      "integrity": "sha512-RifvaH7hfBii8qEts1nH/1w59lBe/vo5rXwBE6UE8S7b23W6I2HbouqwOAR7dGenXTMuuRPohLgmldoj86LNHQ==",
       "dependencies": {
         "@koa/bodyparser": "5.0.0",
         "@koa/cors": "5.0.0",

--- a/bank/bank-backend/package.json
+++ b/bank/bank-backend/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "private": true,
   "dependencies": {
-    "@dbos-inc/dbos-sdk": "^1.15.9",
+    "@dbos-inc/dbos-sdk": "^1.16.12",
     "@koa/bodyparser": "^5.0.0",
     "@koa/cors": "^5.0.0",
     "@koa/router": "^12.0.0",

--- a/bank/bank-backend/src/router.ts
+++ b/bank/bank-backend/src/router.ts
@@ -64,6 +64,15 @@ export class BankEndpoints {
   }
 }
 
+// For demo purposes
+export class CrashEndpoint {
+ @GetApi('/crash_application')
+  static async crashApplication(ctx: HandlerContext) {
+    // For testing and demo purposes :)
+    process.exit(1);
+  }
+}
+
 // Helper functions to convert to the correct data types.
 // Especially convert the bigint.
 export function convertTransactionHistory(data: TransactionHistory): TransactionHistory {

--- a/bank/bank-backend/src/router.ts
+++ b/bank/bank-backend/src/router.ts
@@ -67,7 +67,7 @@ export class BankEndpoints {
 // For demo purposes
 export class CrashEndpoint {
  @GetApi('/crash_application')
-  static async crashApplication(ctx: HandlerContext) {
+  static async crashApplication(_ctx: HandlerContext) {
     // For testing and demo purposes :)
     process.exit(1);
     return Promise.resolve();

--- a/bank/bank-backend/src/router.ts
+++ b/bank/bank-backend/src/router.ts
@@ -70,6 +70,7 @@ export class CrashEndpoint {
   static async crashApplication(ctx: HandlerContext) {
     // For testing and demo purposes :)
     process.exit(1);
+    return Promise.resolve();
   }
 }
 

--- a/bank/bank-frontend/src/app/bank.component.ts
+++ b/bank/bank-frontend/src/app/bank.component.ts
@@ -20,7 +20,7 @@ import { OwnerNameDialogComponent } from './owner-name-dialog/owner-name-dialog.
           <button class="button-grey" (click)="getMsg()" type="submit">New Greeting Message</button>
           <button  class="button-green" (click)="createNewAccount()" type="submit">Create a New Account</button>
           <button  class="button" (click)="getAccounts()" type="submit">Refresh Accounts</button>
-
+          <button  class="button-red" (click)="crashApp()" type="submit">Crash!</button>
       </div>
 
       <table class="table table-striped">
@@ -430,5 +430,10 @@ export class BankComponent {
             },
             error: (err: any) => { this.bankmsg = 'Failed to transfer! '; }
           });
+      }
+
+      //In response to the "Crash" button - for demo purposes
+      crashApp(){
+        this._service.getResource(this.bankUrl + "/crash_application").subscribe()
       }
 }

--- a/bank/bank-frontend/src/styles.css
+++ b/bank/bank-frontend/src/styles.css
@@ -33,6 +33,18 @@
     position: relative;
 }
 
+.button-red {
+  margin: 10px;
+  padding: 15px 20px;
+  background-color: #ff1111;
+  color: white;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  border-radius: 10px; /* Rounded corners */
+  position: relative;
+}
+
 .button-grey {
   margin: 10px;
   padding: 15px 20px;


### PR DESCRIPTION
We improve bank by adding a red `Crash!` button to it :) The button stops the process (like widget store). Combined with a sleep loop in transaction recovery, this makes for a compelling demo. Adde readme for those steps.