### PR TITLE
Reduce the refresh frequency to 1/20s. This generates much less trace…

### DIFF
--- a/python/widget-store/pdm.lock
+++ b/python/widget-store/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:a7b8152a3b7c86a6303efd2a5a7ec3b535700461d77de6939f9e7a414ddb2cdd"
+content_hash = "sha256:c222e86dd1228bb1c9ce577a26508942601ff6e94f8a4107677a8af2fb6eada2"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -201,7 +201,7 @@ files = [
 
 [[package]]
 name = "dbos"
-version = "0.5.0a12"
+version = "0.6.2"
 requires_python = ">=3.9"
 summary = "Ultra-lightweight durable execution in Python"
 groups = ["default"]
@@ -222,8 +222,8 @@ dependencies = [
     "typing-extensions>=4.12.2; python_version < \"3.10\"",
 ]
 files = [
-    {file = "dbos-0.5.0a12-py3-none-any.whl", hash = "sha256:e6ca92b6b9b3cd5ac0bae938beac737d8750b3d9e165e688a0b349498295d3db"},
-    {file = "dbos-0.5.0a12.tar.gz", hash = "sha256:f496f9134b8aecdcbdd87f9c0eeaca89d6e2ca5fa3e99ea0a6eae2672d493622"},
+    {file = "dbos-0.6.2-py3-none-any.whl", hash = "sha256:43fe57689823f80452fac585324b3f953ba93330f90948bdc96b972c70f57a6e"},
+    {file = "dbos-0.6.2.tar.gz", hash = "sha256:42bd4cfc18da68352e01abc6930c68de68728da11fd312cf775553e7670e761d"},
 ]
 
 [[package]]

--- a/python/widget-store/pyproject.toml
+++ b/python/widget-store/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Peter Kraft", email = "petereliaskraft@gmail.com"},
 ]
 dependencies = [
-    "dbos>=0.5.0a12",
+    "dbos==0.6.2",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/python/widget-store/requirements.txt
+++ b/python/widget-store/requirements.txt
@@ -10,7 +10,7 @@ certifi==2024.8.30
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6; platform_system == "Windows" or sys_platform == "win32"
-dbos==0.5.0a12
+dbos==0.6.2
 deprecated==1.2.14
 dnspython==2.6.1
 email-validator==2.2.0

--- a/python/widget-store/widget_store/main.py
+++ b/python/widget-store/widget_store/main.py
@@ -186,7 +186,7 @@ def restock():
 # then dispatches orders that are fully progressed.
 
 
-@DBOS.scheduled("* * * * * */20")
+@DBOS.scheduled("*/20 * * * * *")
 @DBOS.transaction()
 def update_order_progress(scheduled_time, actual_time):
     # Update the progress of paid orders.

--- a/python/widget-store/widget_store/main.py
+++ b/python/widget-store/widget_store/main.py
@@ -182,11 +182,11 @@ def restock():
 
 
 # Now, let's write a scheduled job to dispatch orders that have been paid for.
-# Every second, it updates the progress of every outstanding paid order,
+# Every 20 seconds, it updates the progress of every outstanding paid order,
 # then dispatches orders that are fully progressed.
 
 
-@DBOS.scheduled("* * * * * *")
+@DBOS.scheduled("* * * * * */20")
 @DBOS.transaction()
 def update_order_progress(scheduled_time, actual_time):
     # Update the progress of paid orders.


### PR DESCRIPTION
… data. It also serves as a good example of an actual "non-default" schedule. And it arguably works better with the crash button

TODO: wait for python SDK to change to use "second_at_beginning"