### PR TITLE
Stop generating traces after the task completes

### DIFF
--- a/python/dbos-app-starter/html/app.html
+++ b/python/dbos-app-starter/html/app.html
@@ -100,7 +100,6 @@
                 document.getElementById('status').innerHTML = `Your background task has completed <b>${step} of 10</b> steps`;
                 if (step == 10) {
                     currentId = null
-                    urlParams.set('id', currentId);
                 }
                 hideReconnecting();
             } catch (error) {

--- a/python/dbos-app-starter/html/app.html
+++ b/python/dbos-app-starter/html/app.html
@@ -84,6 +84,7 @@
            
             currentId = randomString;
             await fetch(`/background/${currentId}/10`, { method: 'GET' });
+            document.getElementById('status').innerHTML = `Starting task...`;
             enableCrashButton();
         }
        
@@ -97,6 +98,10 @@
                 }
                 const step = await response.text();
                 document.getElementById('status').innerHTML = `Your background task has completed <b>${step} of 10</b> steps`;
+                if (step == 10) {
+                    currentId = null
+                    urlParams.set('id', currentId);
+                }
                 hideReconnecting();
             } catch (error) {
                 console.error('Error checking progress:', error);


### PR DESCRIPTION
In the starter app, after the background task succeeds, reset the "id" param to stop calling /last_step 