### PR TITLE
Improve Demo Apps

### DIFF
--- a/python/dbos-app-starter/README.md
+++ b/python/dbos-app-starter/README.md
@@ -35,23 +35,10 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
-
-Then initialize local `postgres` running in a container:
-
-```shell
-export PGPASSWORD='my-secure-db'
-python3 start_postgres_docker.py
-```
-
-Then start your app:
+Then start your app. DBOS will automatically guide you through connecting to your app to a Postgres database.
 
 ```shell
 dbos start
 ```
 
 Visit [`http://localhost:8000`](http://localhost:8000) to see your app!
-
-The `PGPASSWORD` environment variable will be needed each time you start your
-app. Or, you can add the password to [database configuration YAML][1].
-
-[1]: https://docs.dbos.dev/typescript/reference/configuration#database

--- a/python/dbos-app-starter/html/app.html
+++ b/python/dbos-app-starter/html/app.html
@@ -135,7 +135,7 @@
         </li>
      </ul>
     <p class="mb-4">
-        Check out the <a href="https://docs.dbos.dev/python/programming-guide" target="_blank" class="text-blue-600 hover:underline">programming guide</a> to learn how to program with DBOS.
+        Check out the <a href="https://docs.dbos.dev/python/programming-guide" target="_blank" class="text-blue-600 hover:underline">programming guide</a> to learn how to program with DBOS!
     </p>
 </div>
 </body>

--- a/python/dbos-app-starter/html/app.html
+++ b/python/dbos-app-starter/html/app.html
@@ -15,7 +15,10 @@
         <span class="text-yellow-700">Reconnecting...</span>
     </div>
     <p class="mb-4">
-        DBOS helps you build applications that are <strong>resilient to any failure</strong>&mdash;no matter how many times you crash this app, your background task will always recover from its last completed step in about ten seconds.
+        DBOS helps you build applications that are <strong>resilient to any failure</strong>.
+    </p>
+    <p class="mb-4">
+       Try it: Start a background task, crash the server, and watch it restart (if you're running this demo locally, restart the server manually). Your task will automatically continue from the step where it left off!
     </p>
     <div class="flex gap-4 mb-4">
         <button
@@ -109,23 +112,31 @@
         }
     </script>
     <p class="mb-4">
-        After finishing a background task, visit <a href="https://console.dbos.dev/traces" target="_blank" class="text-blue-600 hover:underline">https://console.dbos.dev/traces</a> to see its traces.
+        To build your own crashproof application:
     </p>
-    <p class="mb-4">
-        Visit your <a href="https://console.dbos.dev/dashboard" target="_blank" class="text-blue-600 hover:underline">dashboard</a>
-        to view logs and metrics for your app.
-        Each time you crash your app, you should see a log entry indicating your
-        <code class="bg-gray-100 px-1 rounded">application became unresponsive</code>,
-        followed by a log entry for a new executor starting up
-        (<code class="bg-gray-100 px-1 rounded">DBOS launched</code>).
-        Then, any background tasks executing before the crash should resume from
-        their last completed step.
-    </p>
-    <p class="mb-4">
-        To start building your own crashproof application, access your source code from the <a href="https://console.dbos.dev/applications/dbos-app-starter" target="_blank" class="text-blue-600 hover:underline">cloud console</a>, edit <code class="bg-gray-100 px-1 rounded">app/main.py</code>, then redeploy your app.
-    </p>
+    <ul class="space-y-3 mb-4">
+        <li class="flex items-start">
+            <span class="flex-shrink-0 h-5 w-5 rounded-full bg-blue-100 flex items-center justify-center mr-2">
+                <span class="text-blue-600 text-sm">1</span>
+            </span>
+            <code class="bg-gray-100 px-2 py-0.5 rounded">pip install dbos</code>
+        </li>
+        <li class="flex items-start">
+            <span class="flex-shrink-0 h-5 w-5 rounded-full bg-blue-100 flex items-center justify-center mr-2">
+                <span class="text-blue-600 text-sm">2</span>
+            </span>
+            <code class="bg-gray-100 px-2 py-0.5 rounded">dbos init --template dbos-app-starter</code>
+        </li>
+        <li class="flex items-start">
+            <span class="flex-shrink-0 h-5 w-5 rounded-full bg-blue-100 flex items-center justify-center mr-2">
+                <span class="text-blue-600 text-sm">3</span>
+            </span>
+            Edit <code class="bg-gray-100 px-2 py-0.5 rounded">app/main.py</code> to start building!
+        </li>
+     </ul>
     <p class="mb-4">
         To learn how to build crashproof apps with DBOS, check out the <a href="https://docs.dbos.dev/python/programming-guide" target="_blank" class="text-blue-600 hover:underline">programming guide</a>!
     </p>
+</div>
 </body>
 </html>

--- a/python/dbos-app-starter/html/app.html
+++ b/python/dbos-app-starter/html/app.html
@@ -135,7 +135,7 @@
         </li>
      </ul>
     <p class="mb-4">
-        Check out the <a href="https://docs.dbos.dev/python/programming-guide" target="_blank" class="text-blue-600 hover:underline">programming guide</a> to learn how to program with DBOS!
+        Check out the <a href="https://docs.dbos.dev/python/programming-guide" target="_blank" class="text-blue-600 hover:underline">programming guide</a> to learn how to build with DBOS!
     </p>
 </div>
 </body>

--- a/python/dbos-app-starter/html/app.html
+++ b/python/dbos-app-starter/html/app.html
@@ -135,7 +135,7 @@
         </li>
      </ul>
     <p class="mb-4">
-        To learn how to build crashproof apps with DBOS, check out the <a href="https://docs.dbos.dev/python/programming-guide" target="_blank" class="text-blue-600 hover:underline">programming guide</a>!
+        Check out the <a href="https://docs.dbos.dev/python/programming-guide" target="_blank" class="text-blue-600 hover:underline">programming guide</a> to learn how to program with DBOS.
     </p>
 </div>
 </body>

--- a/python/dbos-app-starter/html/app.html
+++ b/python/dbos-app-starter/html/app.html
@@ -18,7 +18,10 @@
         DBOS helps you build applications that are <strong>resilient to any failure</strong>.
     </p>
     <p class="mb-4">
-       Try it: Start a background task, crash the server, and watch it restart (if you're running this demo locally, restart the server manually). Your task will automatically continue from the step where it left off!
+       Try it: Start a background task, crash the application, then watch it restart. Your task will automatically continue from the step where it left off!
+    </p>
+    <p class="mb-4">
+       If you check your app's logs (viewable <a href="https://console.dbos.dev/applications/dbos-app-starter" target="_blank" class="text-blue-600 hover:underline">here</a> in DBOS Cloud), you can see your app become unresponsive, then restart, then recover any active background tasks.
     </p>
     <div class="flex gap-4 mb-4">
         <button


### PR DESCRIPTION
Goal is to tighten `dbos-app-starter` to make it clear both:

1. What to expect when running it (following up on https://github.com/dbos-inc/dbos-demo-apps/pull/258).
2. How to get started developing locally (making use of the new automatic database setup feature, which lets us simplify the instructions from https://github.com/dbos-inc/dbos-demo-apps/pull/257).

New look:

![image](https://github.com/user-attachments/assets/48c83930-c1f0-41ca-9f35-438f2f467372)

