### PR TITLE
Inherit theme color for calendar toolbar buttons to make sure they are readable in dark mode

### DIFF
--- a/typescript/nextjs-calendar/src/components/CalendarView.tsx
+++ b/typescript/nextjs-calendar/src/components/CalendarView.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import "react-big-calendar/lib/css/react-big-calendar.css";
+import "../themes/calendarToolbarButtonStyles.css";
 import { fetchSchedules, fetchResults, deleteSchedule } from '@/actions/schedule';
 import { ScheduleUIRecord, ResultsUIRecord } from '@/types/models';
 import { useState, useEffect, useRef } from 'react';
 import { Paper, Typography, useTheme } from '@mui/material';
 import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mui/material';
 import { Calendar, Views, momentLocalizer } from 'react-big-calendar';
-import "react-big-calendar/lib/css/react-big-calendar.css";
 import { ScheduleForm, ScheduleFormHandle } from './ScheduleForm';
 import ResultsModal from './ResultsModal';
 import moment from 'moment';

--- a/typescript/nextjs-calendar/src/themes/calendarToolbarButtonStyles.css
+++ b/typescript/nextjs-calendar/src/themes/calendarToolbarButtonStyles.css
@@ -1,0 +1,3 @@
+.rbc-toolbar button:not(.rbc-active):not(:hover) {
+  color: inherit;
+}


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/201d5e95-df8b-415f-ad07-e50c69376079)

After:
![image](https://github.com/user-attachments/assets/fcf4e33a-fa62-49e6-be73-5c332f7e0c92)
