### PR TITLE
Upgrade golang widget-store to DBOS 0.9.0

### DIFF
--- a/golang/widget-store/go.mod
+++ b/golang/widget-store/go.mod
@@ -3,7 +3,7 @@ module widget-store
 go 1.23.2
 
 require (
-	github.com/dbos-inc/dbos-transact-golang v0.5.5-beta.0.20250911181830-7741ebeaea84
+	github.com/dbos-inc/dbos-transact-golang v0.9.0
 	github.com/gin-gonic/gin v1.10.1
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/stretchr/testify v1.10.0

--- a/golang/widget-store/go.sum
+++ b/golang/widget-store/go.sum
@@ -10,10 +10,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dbos-inc/dbos-transact-golang v0.5.5-beta h1:mppRd8TmkAnBKs+yGWZ2KFpqG6bO0UFbH92od/ILVSk=
-github.com/dbos-inc/dbos-transact-golang v0.5.5-beta/go.mod h1:/vujZM3WtZoZSJd/cFd02M8ndDLuGaODR6vCcnxCwQY=
-github.com/dbos-inc/dbos-transact-golang v0.5.5-beta.0.20250911181830-7741ebeaea84 h1:AD1jzJz1d2k7kChYy7oyW38r0Yxb53sSQAIBtdmGfIM=
-github.com/dbos-inc/dbos-transact-golang v0.5.5-beta.0.20250911181830-7741ebeaea84/go.mod h1:aIL1pB+wY2l5ooIRZLnx0LTQk9u2VNGfzvJqVPomXtY=
+github.com/dbos-inc/dbos-transact-golang v0.9.0 h1:M3wzWHF8VUTZqC3p78ys2lXlSs+0tSp9vmZFvXmmORc=
+github.com/dbos-inc/dbos-transact-golang v0.9.0/go.mod h1:a9g6XFRciuoDIqJX1yVH0mpw1mrSv62p5dI9Wfr3A8c=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/golang/widget-store/mocks/DBOSContext_mock.go
+++ b/golang/widget-store/mocks/DBOSContext_mock.go
@@ -831,6 +831,145 @@ func (_c *MockDBOSContext_Launch_Call) RunAndReturn(run func() error) *MockDBOSC
 	return _c
 }
 
+// ListRegisteredQueues provides a mock function for the type MockDBOSContext
+func (_mock *MockDBOSContext) ListRegisteredQueues(dBOSContext dbos.DBOSContext) ([]dbos.WorkflowQueue, error) {
+	ret := _mock.Called(dBOSContext)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListRegisteredQueues")
+	}
+
+	var r0 []dbos.WorkflowQueue
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(dbos.DBOSContext) ([]dbos.WorkflowQueue, error)); ok {
+		return returnFunc(dBOSContext)
+	}
+	if returnFunc, ok := ret.Get(0).(func(dbos.DBOSContext) []dbos.WorkflowQueue); ok {
+		r0 = returnFunc(dBOSContext)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]dbos.WorkflowQueue)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(dbos.DBOSContext) error); ok {
+		r1 = returnFunc(dBOSContext)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDBOSContext_ListRegisteredQueues_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListRegisteredQueues'
+type MockDBOSContext_ListRegisteredQueues_Call struct {
+	*mock.Call
+}
+
+// ListRegisteredQueues is a helper method to define mock.On call
+//   - dBOSContext dbos.DBOSContext
+func (_e *MockDBOSContext_Expecter) ListRegisteredQueues(dBOSContext interface{}) *MockDBOSContext_ListRegisteredQueues_Call {
+	return &MockDBOSContext_ListRegisteredQueues_Call{Call: _e.mock.On("ListRegisteredQueues", dBOSContext)}
+}
+
+func (_c *MockDBOSContext_ListRegisteredQueues_Call) Run(run func(dBOSContext dbos.DBOSContext)) *MockDBOSContext_ListRegisteredQueues_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 dbos.DBOSContext
+		if args[0] != nil {
+			arg0 = args[0].(dbos.DBOSContext)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDBOSContext_ListRegisteredQueues_Call) Return(queues []dbos.WorkflowQueue, err error) *MockDBOSContext_ListRegisteredQueues_Call {
+	_c.Call.Return(queues, err)
+	return _c
+}
+
+func (_c *MockDBOSContext_ListRegisteredQueues_Call) RunAndReturn(run func(dBOSContext dbos.DBOSContext) ([]dbos.WorkflowQueue, error)) *MockDBOSContext_ListRegisteredQueues_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListRegisteredWorkflows provides a mock function for the type MockDBOSContext
+func (_mock *MockDBOSContext) ListRegisteredWorkflows(dBOSContext dbos.DBOSContext, opts ...dbos.ListRegisteredWorkflowsOption) ([]dbos.WorkflowRegistryEntry, error) {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(dBOSContext, opts)
+	} else {
+		tmpRet = _mock.Called(dBOSContext)
+	}
+	ret := tmpRet
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListRegisteredWorkflows")
+	}
+
+	var r0 []dbos.WorkflowRegistryEntry
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(dbos.DBOSContext, ...dbos.ListRegisteredWorkflowsOption) ([]dbos.WorkflowRegistryEntry, error)); ok {
+		return returnFunc(dBOSContext, opts...)
+	}
+	if returnFunc, ok := ret.Get(0).(func(dbos.DBOSContext, ...dbos.ListRegisteredWorkflowsOption) []dbos.WorkflowRegistryEntry); ok {
+		r0 = returnFunc(dBOSContext, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]dbos.WorkflowRegistryEntry)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(dbos.DBOSContext, ...dbos.ListRegisteredWorkflowsOption) error); ok {
+		r1 = returnFunc(dBOSContext, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDBOSContext_ListRegisteredWorkflows_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListRegisteredWorkflows'
+type MockDBOSContext_ListRegisteredWorkflows_Call struct {
+	*mock.Call
+}
+
+// ListRegisteredWorkflows is a helper method to define mock.On call
+//   - dBOSContext dbos.DBOSContext
+//   - opts ...dbos.ListRegisteredWorkflowsOption
+func (_e *MockDBOSContext_Expecter) ListRegisteredWorkflows(dBOSContext interface{}, opts ...interface{}) *MockDBOSContext_ListRegisteredWorkflows_Call {
+	return &MockDBOSContext_ListRegisteredWorkflows_Call{Call: _e.mock.On("ListRegisteredWorkflows",
+		append([]interface{}{dBOSContext}, opts...)...)}
+}
+
+func (_c *MockDBOSContext_ListRegisteredWorkflows_Call) Run(run func(dBOSContext dbos.DBOSContext, opts ...dbos.ListRegisteredWorkflowsOption)) *MockDBOSContext_ListRegisteredWorkflows_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 dbos.DBOSContext
+		if args[0] != nil {
+			arg0 = args[0].(dbos.DBOSContext)
+		}
+		var arg1 []dbos.ListRegisteredWorkflowsOption
+		var variadicArgs []dbos.ListRegisteredWorkflowsOption
+		if len(args) > 1 {
+			variadicArgs = args[1].([]dbos.ListRegisteredWorkflowsOption)
+		}
+		arg1 = variadicArgs
+		run(
+			arg0,
+			arg1...,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDBOSContext_ListRegisteredWorkflows_Call) Return(entries []dbos.WorkflowRegistryEntry, err error) *MockDBOSContext_ListRegisteredWorkflows_Call {
+	_c.Call.Return(entries, err)
+	return _c
+}
+
+func (_c *MockDBOSContext_ListRegisteredWorkflows_Call) RunAndReturn(run func(dBOSContext dbos.DBOSContext, opts ...dbos.ListRegisteredWorkflowsOption) ([]dbos.WorkflowRegistryEntry, error)) *MockDBOSContext_ListRegisteredWorkflows_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListWorkflows provides a mock function for the type MockDBOSContext
 func (_mock *MockDBOSContext) ListWorkflows(dBOSContext dbos.DBOSContext, opts ...dbos.ListWorkflowsOption) ([]dbos.WorkflowStatus, error) {
 	var tmpRet mock.Arguments


### PR DESCRIPTION
Disclaimer: I wrote this with Claude Code.

This upgrades DBOS to 0.9.0 for the Golang widget-store demo.  I did this because I had trouble connecting to Conductor with the project I'm working on, so I wanted to check whether it was the DBOS version (it was not).  Please feel free to close if you don't think it's worth the trouble.

I verified that the web app still works, it still connects to Conductor if the env vars are set, and the tests pass.