### PR TITLE
Fix order polling never stopping after dispatch completes

### DIFF
--- a/golang/widget-store/html/app.html
+++ b/golang/widget-store/html/app.html
@@ -295,9 +295,6 @@
 
               // Set up periodic order updates
               this.startUpdateOrdersInterval();
-              setInterval(() => {
-                this.startUpdateOrdersInterval();
-              }, 3000);
             }
           );
         },


### PR DESCRIPTION
## Summary
- Remove unconditional `setInterval` that restarted order polling every 3 seconds in the widget store demo
- The inner polling logic correctly stops when no PAID orders remain, but the outer loop was overriding it by restarting polling unconditionally
- Polling still restarts appropriately when a new checkout occurs

## Test plan
- [ ] Place an order and complete payment
- [ ] Wait for order to reach DISPATCHED status with `progress_remaining: 0`
- [ ] Verify browser network tab shows `/orders` polling has stopped
- [ ] Place a new order and verify polling resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)