### PR TITLE
This fixes a problem when we ask the agent 'show me purchases 1, 2, and 3'

### DIFF
--- a/python/reliable-refunds-langchain/reliable_refunds/main.py
+++ b/python/reliable-refunds-langchain/reliable_refunds/main.py
@@ -150,7 +150,7 @@ class State(TypedDict):
 def create_agent():
     llm = ChatOpenAI(model="gpt-4.1-mini")
     tools = [tool_get_purchase_by_id, process_refund]
-    llm_with_tools = llm.bind_tools(tools)
+    llm_with_tools = llm.bind_tools(tools, parallel_tool_calls=False)
 
     prompt = ChatPromptTemplate.from_messages(
         [


### PR DESCRIPTION
I believe this is due to dbos requiring only one langchain tool call per DBOS.transaction.  To replicate the original error run the demo and as the agent 'show me purchases 1, 2, and 3'.  The error message that this PR fixes is pasted below, including the startup logging:

```
Executing start commands from 'dbos-config.yaml'
Executing: fastapi run reliable_refunds/main.py

   FastAPI   Starting production server 🚀

             Searching for package file structure from directories with __init__.py files
/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langchain_core/_api/deprecation.py:25: UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.
  from pydantic.v1.fields import FieldInfo as FieldInfoV1
Using database connection string: postgresql://kaze7539:*****@127.0.0.1:5432/postgres
13:26:33 [    INFO] (dbos:_dbos.py:371) Initializing DBOS
             Importing from /Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain

    module   📁 reliable_refunds
             ├── 🐍 __init__.py
             └── 🐍 main.py

      code   Importing the FastAPI app object from the module with the following code:

             from reliable_refunds.main import app

       app   Using import string: reliable_refunds.main:app

    server   Server started at http://0.0.0.0:8000
    server   Documentation at http://0.0.0.0:8000/docs

             Logs:

      INFO   Started server process [54914]
      INFO   Waiting for application startup.
13:26:33 [    INFO] (dbos:_dbos.py:449) Executor ID: local
13:26:33 [    INFO] (dbos:_dbos.py:450) Application version: e82ed5024bb25d5c46bc5291a1d81921
13:26:33 [ WARNING] (dbos:_sys_db.py:230) Exception during system database construction. This is most likely because the system database was configured using a later version of DBOS: Can't locate revision identified by '933e86bdac6a'
13:26:33 [ WARNING] (dbos:_sys_db.py:245) Exception during system database construction. This is most likely because the system database was configured using a later version of DBOS: Can't locate revision identified by '933e86bdac6a'
13:26:33 [    INFO] (dbos:_dbos.py:478) No workflows to recover from application version e82ed5024bb25d5c46bc5291a1d81921
13:26:33 [    INFO] (dbos:_dbos.py:535) DBOS launched!
      INFO   Application startup complete.
      INFO   Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
13:26:42 [    INFO] (dbos:main.py:57) Looking up purchase by order_id 1
      INFO   127.0.0.1:63237 - "POST /chat HTTP/1.1" 500
     ERROR   Exception in ASGI application
Traceback (most recent call last):
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/uvicorn/protocols/http/httptools_impl.py", line 416, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        self.scope, self.receive, self.send
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/fastapi/applications.py", line 1163, in __call__
    await super().__call__(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/applications.py", line 90, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/middleware/base.py", line 191, in __call__
    with recv_stream, send_stream, collapse_excgroups():
                                   ~~~~~~~~~~~~~~~~~~^^
  File "/Users/kaze7539/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/contextlib.py", line 162, in __exit__
    self.gen.throw(value)
    ~~~~~~~~~~~~~~^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/_utils.py", line 87, in collapse_excgroups
    raise exc
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/middleware/base.py", line 193, in __call__
    response = await self.dispatch_func(request, call_next)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/dbos/_fastapi.py", line 104, in dbos_fastapi_middleware
    response = await call_next(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/middleware/base.py", line 168, in call_next
    raise app_exc from app_exc.__cause__ or app_exc.__context__
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/middleware/base.py", line 144, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/dbos/_fastapi.py", line 75, in __call__
    await self.app(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/routing.py", line 660, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/routing.py", line 680, in app
    await route.handle(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/fastapi/routing.py", line 134, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/fastapi/routing.py", line 120, in app
    response = await f(request)
               ^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/fastapi/routing.py", line 674, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
    )
    ^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/fastapi/routing.py", line 330, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/concurrency.py", line 32, in run_in_threadpool
    return await anyio.to_thread.run_sync(func)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/anyio/to_thread.py", line 63, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        func, args, abandon_on_cancel=abandon_on_cancel, limiter=limiter
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/anyio/_backends/_asyncio.py", line 2518, in run_sync_in_worker_thread
    return await future
           ^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/anyio/_backends/_asyncio.py", line 1002, in run
    result = context.run(func, *args)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/reliable_refunds/main.py", line 216, in chat_workflow
    for event in events:
                 ^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/pregel/main.py", line 2727, in stream
    for _ in runner.tick(
             ~~~~~~~~~~~^
        [t for t in loop.tasks.values() if not t.writes],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        schedule_task=loop.accept_push,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ):
    ^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/pregel/_runner.py", line 167, in tick
    run_with_retry(
    ~~~~~~~~~~~~~~^
        t,
        ^^
    ...<10 lines>...
        },
        ^^
    )
    ^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/pregel/_retry.py", line 96, in run_with_retry
    return task.proc.invoke(task.input, config)
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/_internal/_runnable.py", line 656, in invoke
    input = context.run(step.invoke, input, config, **kwargs)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/_internal/_runnable.py", line 400, in invoke
    ret = self.func(*args, **kwargs)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/prebuilt/tool_node.py", line 813, in _func
    outputs = list(
        executor.map(self._run_one, tool_calls, input_types, tool_runtimes)
    )
  File "/Users/kaze7539/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/concurrent/futures/_base.py", line 639, in result_iterator
    yield _result_or_cancel(fs.pop())
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/Users/kaze7539/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/concurrent/futures/_base.py", line 311, in _result_or_cancel
    return fut.result(timeout)
           ~~~~~~~~~~^^^^^^^^^
  File "/Users/kaze7539/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/concurrent/futures/_base.py", line 443, in result
    return self.__get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/Users/kaze7539/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/concurrent/futures/_base.py", line 395, in __get_result
    raise self._exception
  File "/Users/kaze7539/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/concurrent/futures/thread.py", line 86, in run
    result = ctx.run(self.task)
  File "/Users/kaze7539/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/concurrent/futures/thread.py", line 73, in run
    return fn(*args, **kwargs)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langchain_core/runnables/config.py", line 579, in _wrapped_fn
    return contexts.pop().run(fn, *args)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/prebuilt/tool_node.py", line 1024, in _run_one
    return self._execute_tool_sync(tool_request, input_type, config)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/prebuilt/tool_node.py", line 973, in _execute_tool_sync
    content = _handle_tool_error(e, flag=self._handle_tool_errors)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/prebuilt/tool_node.py", line 430, in _handle_tool_error
    content = flag(e)  # type: ignore [assignment, call-arg]
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/prebuilt/tool_node.py", line 387, in _default_handle_tool_errors
    raise e
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/prebuilt/tool_node.py", line 930, in _execute_tool_sync
    response = tool.invoke(call_args, config)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langchain_core/tools/base.py", line 642, in invoke
    return self.run(tool_input, **kwargs)
           ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langchain_core/tools/base.py", line 1001, in run
    raise error_to_raise
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langchain_core/tools/base.py", line 967, in run
    response = context.run(self._run, *tool_args, **tool_kwargs)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langchain_core/tools/structured.py", line 97, in _run
    return self.func(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/reliable_refunds/main.py", line 68, in tool_get_purchase_by_id
    return asdict(get_purchase_by_id(order_id))
                  ~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/dbos/_core.py", line 819, in wrapper
    ctx.is_workflow()
    ~~~~~~~~~~~~~~~^^
AssertionError: Transactions must be called from within workflows
During task with name 'tools' and id 'e8cb8687-2e11-bdfb-8968-5944e131236b'
      INFO   127.0.0.1:63240 - "POST /reset HTTP/1.1" 200
      INFO   127.0.0.1:63240 - "GET / HTTP/1.1" 200
      INFO   127.0.0.1:63240 - "GET /history HTTP/1.1" 200
13:27:15 [    INFO] (dbos:main.py:57) Looking up purchase by order_id 1
      INFO   127.0.0.1:63242 - "POST /chat HTTP/1.1" 500
     ERROR   Exception in ASGI application
Traceback (most recent call last):
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/uvicorn/protocols/http/httptools_impl.py", line 416, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        self.scope, self.receive, self.send
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/fastapi/applications.py", line 1163, in __call__
    await super().__call__(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/applications.py", line 90, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/middleware/base.py", line 191, in __call__
    with recv_stream, send_stream, collapse_excgroups():
                                   ~~~~~~~~~~~~~~~~~~^^
  File "/Users/kaze7539/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/contextlib.py", line 162, in __exit__
    self.gen.throw(value)
    ~~~~~~~~~~~~~~^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/_utils.py", line 87, in collapse_excgroups
    raise exc
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/middleware/base.py", line 193, in __call__
    response = await self.dispatch_func(request, call_next)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/dbos/_fastapi.py", line 104, in dbos_fastapi_middleware
    response = await call_next(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/middleware/base.py", line 168, in call_next
    raise app_exc from app_exc.__cause__ or app_exc.__context__
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/middleware/base.py", line 144, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/dbos/_fastapi.py", line 75, in __call__
    await self.app(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/routing.py", line 660, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/routing.py", line 680, in app
    await route.handle(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/fastapi/routing.py", line 134, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/fastapi/routing.py", line 120, in app
    response = await f(request)
               ^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/fastapi/routing.py", line 674, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
    )
    ^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/fastapi/routing.py", line 330, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/starlette/concurrency.py", line 32, in run_in_threadpool
    return await anyio.to_thread.run_sync(func)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/anyio/to_thread.py", line 63, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        func, args, abandon_on_cancel=abandon_on_cancel, limiter=limiter
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/anyio/_backends/_asyncio.py", line 2518, in run_sync_in_worker_thread
    return await future
           ^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/anyio/_backends/_asyncio.py", line 1002, in run
    result = context.run(func, *args)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/reliable_refunds/main.py", line 216, in chat_workflow
    for event in events:
                 ^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/pregel/main.py", line 2727, in stream
    for _ in runner.tick(
             ~~~~~~~~~~~^
        [t for t in loop.tasks.values() if not t.writes],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        schedule_task=loop.accept_push,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ):
    ^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/pregel/_runner.py", line 167, in tick
    run_with_retry(
    ~~~~~~~~~~~~~~^
        t,
        ^^
    ...<10 lines>...
        },
        ^^
    )
    ^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/pregel/_retry.py", line 96, in run_with_retry
    return task.proc.invoke(task.input, config)
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/_internal/_runnable.py", line 656, in invoke
    input = context.run(step.invoke, input, config, **kwargs)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/_internal/_runnable.py", line 400, in invoke
    ret = self.func(*args, **kwargs)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/prebuilt/tool_node.py", line 813, in _func
    outputs = list(
        executor.map(self._run_one, tool_calls, input_types, tool_runtimes)
    )
  File "/Users/kaze7539/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/concurrent/futures/_base.py", line 639, in result_iterator
    yield _result_or_cancel(fs.pop())
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/Users/kaze7539/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/concurrent/futures/_base.py", line 311, in _result_or_cancel
    return fut.result(timeout)
           ~~~~~~~~~~^^^^^^^^^
  File "/Users/kaze7539/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/concurrent/futures/_base.py", line 443, in result
    return self.__get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/Users/kaze7539/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/concurrent/futures/_base.py", line 395, in __get_result
    raise self._exception
  File "/Users/kaze7539/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/concurrent/futures/thread.py", line 86, in run
    result = ctx.run(self.task)
  File "/Users/kaze7539/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/concurrent/futures/thread.py", line 73, in run
    return fn(*args, **kwargs)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langchain_core/runnables/config.py", line 579, in _wrapped_fn
    return contexts.pop().run(fn, *args)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/prebuilt/tool_node.py", line 1024, in _run_one
    return self._execute_tool_sync(tool_request, input_type, config)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/prebuilt/tool_node.py", line 973, in _execute_tool_sync
    content = _handle_tool_error(e, flag=self._handle_tool_errors)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/prebuilt/tool_node.py", line 430, in _handle_tool_error
    content = flag(e)  # type: ignore [assignment, call-arg]
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/prebuilt/tool_node.py", line 387, in _default_handle_tool_errors
    raise e
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langgraph/prebuilt/tool_node.py", line 930, in _execute_tool_sync
    response = tool.invoke(call_args, config)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langchain_core/tools/base.py", line 642, in invoke
    return self.run(tool_input, **kwargs)
           ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langchain_core/tools/base.py", line 1001, in run
    raise error_to_raise
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langchain_core/tools/base.py", line 967, in run
    response = context.run(self._run, *tool_args, **tool_kwargs)
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/langchain_core/tools/structured.py", line 97, in _run
    return self.func(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/reliable_refunds/main.py", line 68, in tool_get_purchase_by_id
    return asdict(get_purchase_by_id(order_id))
                  ~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/Users/kaze7539/proj/dbos-demo-apps/python/reliable-refunds-langchain/.venv/lib/python3.14/site-packages/dbos/_core.py", line 819, in wrapper
    ctx.is_workflow()
    ~~~~~~~~~~~~~~~^^
AssertionError: Transactions must be called from within workflows
During task with name 'tools' and id '01944801-7e70-3e3e-0835-14604d53f77e'
^C
```