### PR TITLE
Add Tuning Engines AI workflow demo

### DIFF
--- a/typescript/tuning-engines-ai/README.md
+++ b/typescript/tuning-engines-ai/README.md
@@ -1,0 +1,54 @@
+# Tuning Engines governed AI workflow
+
+This example shows how to call a Tuning Engines OpenAI-compatible endpoint from
+a durable DBOS workflow. DBOS owns workflow recovery, retries, step state, and
+database-backed execution. Tuning Engines owns model routing, policy checks,
+approval decisions, usage attribution, and trace correlation.
+
+## Setup
+
+Install dependencies and build the example:
+
+```bash
+npm install
+npm run build
+```
+
+Set a Tuning Engines inference key and model:
+
+```bash
+export TE_INFERENCE_KEY="sk-te-your-inference-key"
+export TE_MODEL="auto"
+```
+
+Start Postgres, or set `DBOS_SYSTEM_DATABASE_URL` if you already have a
+database:
+
+```bash
+npx dbos postgres start
+```
+
+## Run
+
+```bash
+npm start -- "Draft a rollout checklist for a new support agent"
+```
+
+The CLI prints the DBOS workflow ID. If the process is interrupted, rerun with
+the same workflow ID and DBOS will recover from durable workflow history:
+
+```bash
+npm start -- "Draft a rollout checklist for a new support agent" --workflow-id <id>
+```
+
+## What the example demonstrates
+
+- A DBOS workflow wraps the model call in `DBOS.runStep`.
+- The model call uses the Tuning Engines `/v1/chat/completions` endpoint.
+- The workflow passes `X-TE-Run-ID` and `X-TE-Request-ID` headers so Tuning
+  Engines can correlate provider usage, policy decisions, approvals, and trace
+  events.
+- A follow-up durable step posts an observed-only trace to `/api/v1/traces`.
+
+Use the same `run_id` when recording state references or outcomes so DBOS
+workflow history and Tuning Engines runtime traces stay linked.

--- a/typescript/tuning-engines-ai/dbos-config.yaml
+++ b/typescript/tuning-engines-ai/dbos-config.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/dbos-inc/dbos-transact-ts/refs/heads/main/dbos-config.schema.json
+
+name: tuning-engines-ai
+language: node
+system_database_url: ${DBOS_SYSTEM_DATABASE_URL}

--- a/typescript/tuning-engines-ai/package-lock.json
+++ b/typescript/tuning-engines-ai/package-lock.json
@@ -1,0 +1,332 @@
+{
+  "name": "tuning-engines-ai",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tuning-engines-ai",
+      "version": "1.0.0",
+      "dependencies": {
+        "@dbos-inc/dbos-sdk": "^4.18.10",
+        "commander": "^12.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.5.1",
+        "typescript": "^5.5.4"
+      }
+    },
+    "node_modules/@dbos-inc/dbos-sdk": {
+      "version": "4.18.10",
+      "resolved": "https://registry.npmjs.org/@dbos-inc/dbos-sdk/-/dbos-sdk-4.18.10.tgz",
+      "integrity": "sha512-4C2ZGCr3S7e7dpor76/MUXZzUwyxQTSCkqA3z53qcxhIQ3hrXNseVeAwYFcEskGlOJGGqQ73j68EB4I7B3nJCQ==",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "commander": "^12.0.0",
+        "pg": "^8.11.3",
+        "serialize-error": "^8.1.0",
+        "superjson": "^1.13.3",
+        "ws": "^8.18.1",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "dbos": "dist/src/cli/cli.js",
+        "dbos-sdk": "dist/src/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.13.3.tgz",
+      "integrity": "sha512-mJiVjfd2vokfDxsQPOwJ/PtanO87LhpYY88ubI5dUB1Ab58Txbyje3+jpm+/83R/fevaq/107NNhtYBLuoTrFg==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/typescript/tuning-engines-ai/package.json
+++ b/typescript/tuning-engines-ai/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "tuning-engines-ai",
+  "version": "1.0.0",
+  "description": "DBOS durable workflow example using Tuning Engines as a governed AI endpoint",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@dbos-inc/dbos-sdk": "^4.18.10",
+    "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.1",
+    "typescript": "^5.5.4"
+  }
+}

--- a/typescript/tuning-engines-ai/src/index.ts
+++ b/typescript/tuning-engines-ai/src/index.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { Command } from "commander";
+import { DBOS } from "@dbos-inc/dbos-sdk";
+import { randomUUID } from "crypto";
+import { governedAiWorkflow, GovernedAiResult } from "./workflows";
+
+const program = new Command();
+
+function newId(prefix: string): string {
+  return `${prefix}_${randomUUID().replace(/-/g, "")}`;
+}
+
+function printResult(result: GovernedAiResult): void {
+  console.log("\nTuning Engines response");
+  console.log("=".repeat(60));
+  console.log(result.content);
+  console.log("=".repeat(60));
+  console.log(`run_id: ${result.run_id}`);
+  console.log(`request_id: ${result.request_id}`);
+  console.log(`trace_status: ${result.trace_status}`);
+}
+
+async function run(prompt: string, options: { workflowId?: string }): Promise<void> {
+  if (!process.env.TE_INFERENCE_KEY) {
+    console.error("TE_INFERENCE_KEY is required.");
+    process.exit(1);
+  }
+
+  DBOS.setConfig({
+    name: "tuning-engines-ai",
+    applicationVersion: "1.0.0",
+    systemDatabaseUrl:
+      process.env.DBOS_SYSTEM_DATABASE_URL ||
+      "postgresql://postgres:dbos@localhost:5432/tuning_engines_ai_dbos_sys",
+  });
+  await DBOS.launch({ conductorKey: process.env.CONDUCTOR_KEY });
+
+  const workflowId = options.workflowId || newId("dbos");
+  console.log(`Workflow ID: ${workflowId}`);
+
+  const handle = options.workflowId
+    ? await DBOS.retrieveWorkflow(workflowId)
+    : await DBOS.startWorkflow(governedAiWorkflow, { workflowID: workflowId })({
+        prompt,
+        run_id: workflowId,
+      });
+
+  const result = (await handle.getResult()) as GovernedAiResult;
+  printResult(result);
+  await DBOS.shutdown();
+}
+
+program
+  .name("tuning-engines-ai")
+  .description("Run a durable DBOS workflow that calls Tuning Engines")
+  .argument("<prompt>", "Prompt to send to the governed model endpoint")
+  .option("--workflow-id <id>", "Resume an existing DBOS workflow")
+  .action((prompt: string, options: { workflowId?: string }) => {
+    run(prompt, options).catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+  });
+
+program.parse();

--- a/typescript/tuning-engines-ai/src/tuning-engines.ts
+++ b/typescript/tuning-engines-ai/src/tuning-engines.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from "crypto";
+
+const TE_API_BASE = process.env.TE_API_BASE || "https://app.tuningengines.com";
+const TE_INFERENCE_BASE =
+  process.env.TE_INFERENCE_BASE || "https://api.tuningengines.com/v1";
+const TE_MODEL = process.env.TE_MODEL || "auto";
+
+export interface ModelCallInput {
+  prompt: string;
+  run_id: string;
+}
+
+export interface ModelCallResult {
+  content: string;
+  request_id: string;
+  model: string;
+}
+
+export interface TraceResult {
+  status: "recorded" | "skipped" | "failed";
+}
+
+function newId(prefix: string): string {
+  return `${prefix}_${randomUUID().replace(/-/g, "")}`;
+}
+
+export async function callTuningEngines(input: ModelCallInput): Promise<ModelCallResult> {
+  const request_id = newId("req");
+  const response = await fetch(`${TE_INFERENCE_BASE}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.TE_INFERENCE_KEY}`,
+      "Content-Type": "application/json",
+      "X-TE-Run-ID": input.run_id,
+      "X-TE-Request-ID": request_id,
+    },
+    body: JSON.stringify({
+      model: TE_MODEL,
+      messages: [{ role: "user", content: input.prompt }],
+      metadata: {
+        run_id: input.run_id,
+        request_id,
+        runtime: "dbos",
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Tuning Engines request failed: ${response.status} ${await response.text()}`);
+  }
+
+  const payload = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+    model?: string;
+  };
+
+  return {
+    content: payload.choices?.[0]?.message?.content || "",
+    request_id,
+    model: payload.model || TE_MODEL,
+  };
+}
+
+export async function recordTrace(input: {
+  prompt: string;
+  run_id: string;
+  request_id: string;
+  model: string;
+}): Promise<TraceResult> {
+  const token = process.env.TE_TRACE_KEY || process.env.TE_INFERENCE_KEY;
+  if (!token) {
+    return { status: "skipped" };
+  }
+
+  const response = await fetch(`${TE_API_BASE}/api/v1/traces`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      run_id: input.run_id,
+      request_id: input.request_id,
+      name: "dbos-governed-ai",
+      runtime: "dbos",
+      telemetry_source: "sdk",
+      status: "succeeded",
+      metadata: {
+        model: input.model,
+      },
+      events: [
+        {
+          id: `evt_${input.request_id}`,
+          type: "model.call",
+          status: "succeeded",
+          metadata: {
+            request_id: input.request_id,
+            run_id: input.run_id,
+            model: input.model,
+            prompt_length: input.prompt.length,
+          },
+        },
+      ],
+    }),
+  });
+
+  return { status: response.ok ? "recorded" : "failed" };
+}

--- a/typescript/tuning-engines-ai/src/workflows.ts
+++ b/typescript/tuning-engines-ai/src/workflows.ts
@@ -1,0 +1,42 @@
+import { DBOS } from "@dbos-inc/dbos-sdk";
+import { callTuningEngines, recordTrace } from "./tuning-engines";
+
+export interface GovernedAiInput {
+  prompt: string;
+  run_id: string;
+}
+
+export interface GovernedAiResult {
+  content: string;
+  run_id: string;
+  request_id: string;
+  trace_status: string;
+}
+
+async function governedAiWorkflowFunction(input: GovernedAiInput): Promise<GovernedAiResult> {
+  const modelResult = await DBOS.runStep(() => callTuningEngines(input), {
+    name: "callTuningEngines",
+  });
+
+  const traceResult = await DBOS.runStep(
+    () =>
+      recordTrace({
+        prompt: input.prompt,
+        run_id: input.run_id,
+        request_id: modelResult.request_id,
+        model: modelResult.model,
+      }),
+    { name: "recordTuningEnginesTrace" },
+  );
+
+  return {
+    content: modelResult.content,
+    run_id: input.run_id,
+    request_id: modelResult.request_id,
+    trace_status: traceResult.status,
+  };
+}
+
+export const governedAiWorkflow = DBOS.registerWorkflow(governedAiWorkflowFunction, {
+  name: "governedAiWorkflow",
+});

--- a/typescript/tuning-engines-ai/tsconfig.json
+++ b/typescript/tuning-engines-ai/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Adds a TypeScript DBOS demo app for a durable AI workflow using Tuning Engines as a governed OpenAI-compatible endpoint.

This follows the guidance from dbos-inc/dbos-transact-ts#1259 by placing the example in dbos-demo-apps instead of the core SDK repo.

What it demonstrates:
- DBOS owns workflow identity, recovery, and durable steps.
- The model call runs inside DBOS.runStep.
- Tuning Engines receives X-TE-Run-ID and X-TE-Request-ID for usage, policy, approval, and trace correlation.
- A follow-up durable step posts observed-only trace metadata to /api/v1/traces.

Validation:
- npm install
- npm run build
