### PR TITLE
Fix self-reference path in jvm-demo-apps workflow

### DIFF
--- a/.github/workflows/jvm-demo-apps.yml
+++ b/.github/workflows/jvm-demo-apps.yml
@@ -8,7 +8,7 @@ on:
       - 'kotlin/**'
       - 'scala/**'
       - 'clojure/**'
-      - '.github/workflows/jvm-dbos-starters.yml'
+      - '.github/workflows/jvm-demo-apps.yml'
   pull_request:
     types:
       - ready_for_review
@@ -20,7 +20,7 @@ on:
       - 'kotlin/**'
       - 'scala/**'
       - 'clojure/**'
-      - '.github/workflows/jvm-dbos-starters.yml'
+      - '.github/workflows/jvm-demo-apps.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The paths filter still pointed at the old jvm-dbos-starters.yml filename after the file was renamed, so push/PR events that only touched this workflow file (like the merge that introduced it) never matched a trigger.